### PR TITLE
Clear AsyncStorage on fresh dev launch

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -13,9 +13,23 @@ import {
 } from '@expo-google-fonts/montserrat';
 import {Colors} from '@/constants/theme';
 import {UserProvider} from '@/contexts/user-context';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// TypeScript declaration for global dev flag
+declare global {
+    var __DEV_STORAGE_CLEARED__: boolean | undefined;
+}
 
 // Prevent splash screen from auto-hiding
 SplashScreen.preventAutoHideAsync();
+
+// Clear AsyncStorage on fresh dev launch (persists through hot reload)
+if (__DEV__ && !global.__DEV_STORAGE_CLEARED__) {
+    AsyncStorage.clear()
+        .then(() => console.log('[DEV] AsyncStorage cleared on fresh launch'))
+        .catch((err) => console.warn('[DEV] Failed to clear AsyncStorage:', err));
+    global.__DEV_STORAGE_CLEARED__ = true;
+}
 
 export const unstable_settings = {
     anchor: '(tabs)',


### PR DESCRIPTION
## Description

During development, persisted AsyncStorage data can cause issues when testing fresh app states. This change automatically clears AsyncStorage when the app is freshly launched in development mode, while preserving data during hot reloads.

Added a global flag (`__DEV_STORAGE_CLEARED__`) that persists through hot reloads but resets on fresh app launch, ensuring storage is only cleared on actual app restart.

### Changes Made

- Add AsyncStorage clear logic on fresh dev launch in root layout
- Use global flag to prevent clearing on hot reload
- Add error handling for storage clear failures