### PR TITLE
Add under development message to incomplete screens

### DIFF
--- a/app/(tabs)/agenda.tsx
+++ b/app/(tabs)/agenda.tsx
@@ -1,13 +1,22 @@
-import {StyleSheet} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {ThemedText} from '@/components/themed-text';
 import {ThemedView} from '@/components/themed-view';
+import {Icon} from '@/components/icon';
+import {Colors, Fonts} from '@/constants/theme';
 
 export default function AgendaScreen() {
     return (
         <SafeAreaView style={styles.safeArea} edges={['top']}>
             <ThemedView style={styles.container}>
-                <ThemedText type="title">Agenda</ThemedText>
+                <View style={styles.content}>
+                    <Icon name="exclamationmark.triangle.fill" size={64} color={Colors.light.primaryMuted} />
+                    <ThemedText type="title" style={styles.title}>Agenda</ThemedText>
+                    <ThemedText style={styles.subtitle}>In ontwikkeling</ThemedText>
+                    <ThemedText style={styles.description}>
+                        Deze functie wordt binnenkort beschikbaar.
+                    </ThemedText>
+                </View>
             </ThemedView>
         </SafeAreaView>
     );
@@ -21,6 +30,25 @@ const styles = StyleSheet.create({
         flex: 1,
         justifyContent: 'center',
         alignItems: 'center',
+    },
+    content: {
+        alignItems: 'center',
+        gap: 16,
+        paddingHorizontal: 40,
+    },
+    title: {
+        marginTop: 8,
+    },
+    subtitle: {
+        fontSize: 18,
+        fontFamily: Fonts.semiBold,
+        color: Colors.light.primary,
+    },
+    description: {
+        fontSize: 16,
+        fontFamily: Fonts.regular,
+        color: Colors.light.textMuted,
+        textAlign: 'center',
     },
 });
 

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -1,13 +1,22 @@
-import {StyleSheet} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {ThemedText} from '@/components/themed-text';
 import {ThemedView} from '@/components/themed-view';
+import {Icon} from '@/components/icon';
+import {Colors, Fonts} from '@/constants/theme';
 
 export default function MessagesScreen() {
     return (
         <SafeAreaView style={styles.safeArea} edges={['top']}>
             <ThemedView style={styles.container}>
-                <ThemedText type="title">Berichten</ThemedText>
+                <View style={styles.content}>
+                    <Icon name="exclamationmark.triangle.fill" size={64} color={Colors.light.primaryMuted} />
+                    <ThemedText type="title" style={styles.title}>Berichten</ThemedText>
+                    <ThemedText style={styles.subtitle}>In ontwikkeling</ThemedText>
+                    <ThemedText style={styles.description}>
+                        Deze functie wordt binnenkort beschikbaar.
+                    </ThemedText>
+                </View>
             </ThemedView>
         </SafeAreaView>
     );
@@ -21,6 +30,25 @@ const styles = StyleSheet.create({
         flex: 1,
         justifyContent: 'center',
         alignItems: 'center',
+    },
+    content: {
+        alignItems: 'center',
+        gap: 16,
+        paddingHorizontal: 40,
+    },
+    title: {
+        marginTop: 8,
+    },
+    subtitle: {
+        fontSize: 18,
+        fontFamily: Fonts.semiBold,
+        color: Colors.light.primary,
+    },
+    description: {
+        fontSize: 16,
+        fontFamily: Fonts.regular,
+        color: Colors.light.textMuted,
+        textAlign: 'center',
     },
 });
 

--- a/app/(tabs)/relax.tsx
+++ b/app/(tabs)/relax.tsx
@@ -1,13 +1,22 @@
-import {StyleSheet} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {ThemedText} from '@/components/themed-text';
 import {ThemedView} from '@/components/themed-view';
+import {Icon} from '@/components/icon';
+import {Colors, Fonts} from '@/constants/theme';
 
 export default function RelaxScreen() {
     return (
         <SafeAreaView style={styles.safeArea} edges={['top']}>
             <ThemedView style={styles.container}>
-                <ThemedText type="title">Ontspan</ThemedText>
+                <View style={styles.content}>
+                    <Icon name="exclamationmark.triangle.fill" size={64} color={Colors.light.primaryMuted} />
+                    <ThemedText type="title" style={styles.title}>Ontspan</ThemedText>
+                    <ThemedText style={styles.subtitle}>In ontwikkeling</ThemedText>
+                    <ThemedText style={styles.description}>
+                        Deze functie wordt binnenkort beschikbaar.
+                    </ThemedText>
+                </View>
             </ThemedView>
         </SafeAreaView>
     );
@@ -21,6 +30,25 @@ const styles = StyleSheet.create({
         flex: 1,
         justifyContent: 'center',
         alignItems: 'center',
+    },
+    content: {
+        alignItems: 'center',
+        gap: 16,
+        paddingHorizontal: 40,
+    },
+    title: {
+        marginTop: 8,
+    },
+    subtitle: {
+        fontSize: 18,
+        fontFamily: Fonts.semiBold,
+        color: Colors.light.primary,
+    },
+    description: {
+        fontSize: 16,
+        fontFamily: Fonts.regular,
+        color: Colors.light.textMuted,
+        textAlign: 'center',
     },
 });
 

--- a/app/practice/index.tsx
+++ b/app/practice/index.tsx
@@ -4,7 +4,7 @@ import {router} from 'expo-router';
 import * as Haptics from 'expo-haptics';
 import {ThemedText} from '@/components/themed-text';
 import {ThemedView} from '@/components/themed-view';
-import {Button} from '@/components/button';
+// import {Button} from '@/components/button'; // Temporarily unused - Ontspan module disabled
 import {Icon} from '@/components/icon';
 import {InstructionStep} from '@/components/instruction-step';
 import {Colors, Fonts} from '@/constants/theme';
@@ -175,8 +175,8 @@ export default function PracticeIndexScreen() {
                     isPlayingAudio={isPlayingAudio}
                 />
 
-                {/* Mindfulness Relax Link (if mindfulness step) */}
-                {currentStep.id === 'mindfulness-reminder' && (
+                {/* Temporarily disabled - Ontspan module not ready */}
+                {/* {currentStep.id === 'mindfulness-reminder' && (
                     <View style={styles.actionButtonContainer}>
                         <Button
                             href="/(tabs)/relax"
@@ -188,7 +188,7 @@ export default function PracticeIndexScreen() {
                             Ga naar Ontspan
                         </Button>
                     </View>
-                )}
+                )} */}
 
                 {/* Replay Audio Button (if audioId exists) */}
                 {currentStep.audioId && (


### PR DESCRIPTION
## Description

The Ontspan, Berichten, and Agenda modules are not yet implemented. Instead of hiding these tabs (which looks incomplete), this change adds a user-friendly "In ontwikkeling" (Under development) placeholder message to each screen.

Additionally, the "Ga naar Ontspan" button in the pre-instructions flow is temporarily disabled since the Ontspan module is not ready.

### Changes Made

- Add "In ontwikkeling" placeholder to Ontspan, Berichten, and Agenda screens
- Include warning icon and Dutch explanation text
- Disable "Ga naar Ontspan" button in pre-instructions